### PR TITLE
Images uploaded by tests no longer stick around forever

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -11,7 +11,11 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    if Rails.env.test?
+      "uploads/test/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    else
+      "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+    end
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,12 @@ require 'features/web_helpers'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.after(:all) do
+    if Rails.env.test?
+      FileUtils.rm_rf(Dir["#{Rails.root}/public/uploads/test/user/avatar/[^.]*"])
+    end
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Images which get uploaded as a result of the test suite being run now go into public/uploads/test (by changing store_dir in the AvatarUploader to check if it’s running in the test environment).  Images you upload by interacting with the app via localhost will still be stored on your machine (in public/uploads/model_name etc).

spec_helper now has an after(:all) block to delete image files from the specific path for user avatars (there’s a way to do this without hard-coding the path, but I’m treading lightly here - if we have image uploads in other places later this will need to be addressed).

The whole /uploads directory is in .gitignore already, so no changes made there.  I can’t think of any reason we’d want to change this, but I’m noting it here just in case.